### PR TITLE
Restart a deployment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- Restart a deployment
+
 ## [0.2.0] -2017-11-26
 ### Added
 - Get a single secret's decoded value

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Some examples:
 kcu secret list production/worker
 kcu secret get production/worker sidekiq_concurrency
 kcu secret set production/worker sidekiq_concurrency 10
+kcu controller restart production/website
 ```
 
 ## Development

--- a/kcu.gemspec
+++ b/kcu.gemspec
@@ -37,4 +37,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 1.15"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "timecop"
 end

--- a/lib/kcu.rb
+++ b/lib/kcu.rb
@@ -16,10 +16,11 @@ require "kcu/services/secrets/decode_data"
 require "kcu/services/secrets/get_entry_value"
 require "kcu/services/secrets/encode_entry_value"
 require "kcu/services/secrets/set_entry_value"
-require "kcu/services/secrets/get_entry_value"
+require "kcu/services/deployments/restart_deployment"
 require "kcu/actions/list_secret_action"
 require "kcu/actions/get_secret_action"
 require "kcu/actions/set_secret_action"
+require "kcu/actions/restart_deployment_action"
 require "kcu/client"
 
 Kcu.new.run if $0 == __FILE__

--- a/lib/kcu/actions/restart_deployment_action.rb
+++ b/lib/kcu/actions/restart_deployment_action.rb
@@ -1,0 +1,14 @@
+module Kcu
+  class RestartDeploymentAction
+
+    extend LightService::Organizer
+
+    def self.call(resource)
+      ctx = with(resource: resource).reduce(
+        GetResourceNamespaceAndName,
+        Deployments::RestartDeployment,
+      )
+    end
+
+  end
+end

--- a/lib/kcu/client.rb
+++ b/lib/kcu/client.rb
@@ -34,6 +34,14 @@ module Kcu
         end
       end
 
+      command :"deployment restart" do |c|
+        c.syntax = "deployment restart namespace/deployment_name"
+        c.description = "Restarts a deployment"
+        c.action do |args, options|
+          RestartDeploymentAction.(*args)
+        end
+      end
+
       run!
     end
 

--- a/lib/kcu/services/deployments/restart_deployment.rb
+++ b/lib/kcu/services/deployments/restart_deployment.rb
@@ -1,0 +1,29 @@
+module Kcu
+  module Deployments
+    class RestartDeployment
+
+      extend LightService::Action
+      expects :resource_namespace, :resource_name
+
+      executed do |c|
+        json = { spec: { template: { metadata: { annotations: {
+          kcu_restarted_at: Time.now.to_i.to_s,
+        } } } } }.to_json
+
+        shell_command = [
+          "kubectl",
+          "patch",
+          "deployment",
+          c.resource_name,
+          "--namespace=#{c.resource_namespace}",
+          ["--patch", "'#{json}'"].join("=")
+        ].join(" ")
+
+        stdout_str, stderr_str, status = Open3.capture3(shell_command)
+
+        puts stdout_str
+      end
+
+    end
+  end
+end

--- a/spec/lib/kcu/services/deployments/restart_deployment_spec.rb
+++ b/spec/lib/kcu/services/deployments/restart_deployment_spec.rb
@@ -1,0 +1,25 @@
+require 'spec_helper'
+
+module Kcu
+  module Deployments
+    RSpec.describe RestartDeployment do
+
+      let(:json) do
+        { spec: { template: { metadata: { annotations: {
+          kcu_restarted_at: Time.now.to_i.to_s,
+        } } } } }.to_json
+      end
+
+      it "restarts the deployment by setting an annotation" do
+        Timecop.freeze
+
+        expect(Open3).to receive(:capture3).
+          with(%Q(kubectl patch deployment web --namespace=prod --patch='#{json}')).
+          and_return([nil, nil, 0])
+
+        described_class.execute(resource_namespace: "prod", resource_name: "web")
+      end
+
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,7 @@ require "bundler/setup"
 require "kcu"
 require "fileutils"
 require "pathname"
+require "timecop"
 
 SPEC_DIR = Pathname.new(File.dirname(__FILE__))
 


### PR DESCRIPTION
Restart a deployment by adding an annotation to `spec.template.metadata.annotations.kcu_restarted_at` with the Unix timestamp of when the restart was triggered.