### PR TITLE
Move pry-byebug to spec helper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+
+## [0.8.0] - 2017-03-11
+### Fixed
+- Move pry-byebug require to `spec_helper`
+
 ## [0.7.0] - 2017-02-01
 ### Added
 - Set secret from file

--- a/lib/kcu/client.rb
+++ b/lib/kcu/client.rb
@@ -1,5 +1,3 @@
-require "pry-byebug"
-
 module Kcu
   class Client
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,8 @@
 require "bundler/setup"
-require "kcu"
 require "fileutils"
+require "kcu"
 require "pathname"
+require "pry-byebug"
 require "timecop"
 
 SPEC_DIR = Pathname.new(File.dirname(__FILE__))


### PR DESCRIPTION
## Description

When you install the kcu gem, it needs `pry-byebug` to be installed on the system first before you can use it.

## Solution

Move the requiring of `pry-byebug` to `spec_helper` from `lib/kcu/client.rb` since it is not being used in the app code.